### PR TITLE
In case there is an exception in TEventBus.InvokeSubscriber, re-raise…

### DIFF
--- a/source/EventBus.pas
+++ b/source/EventBus.pas
@@ -148,8 +148,20 @@ end;
 procedure TEventBus.InvokeSubscriber(ASubscription: TSubscription;
   AEvent: TObject);
 begin
-  ASubscription.SubscriberMethod.Method.Invoke(ASubscription.Subscriber,
-    [AEvent]);
+  try
+    ASubscription.SubscriberMethod.Method.Invoke(ASubscription.Subscriber,
+      [AEvent]);
+  except
+    on E: Exception do
+    begin
+      raise Exception.CreateFmt(
+        'Error invoking subscriber method. Subscriber class: %s. Event type: %s. Original exception: %s: %s',
+        [ASubscription.Subscriber.ClassName,
+         ASubscription.SubscriberMethod.EventType.ClassName,
+         E.ClassName, E.Message
+        ]);
+    end;
+  end;
 end;
 
 function TEventBus.IsRegistered(ASubscriber: TObject): Boolean;


### PR DESCRIPTION
… a new exception with the names of both the related subscriber object and method shown in the message.

This is very helpful for locating the error.

Example exception message:
Error invoking subscriber method. Subscriber class: TfrmMain. Event type: TEventFileOpenNotification. Original exception: EAccessViolation: Access violation at address 00409A57 in module 'program1.exe'. Read of address FFFFFFF0.