### PR TITLE
Avoid 'Access Violation' when subscription no longer active

### DIFF
--- a/source/EventBus.pas
+++ b/source/EventBus.pas
@@ -130,8 +130,11 @@ function TEventBus.GenerateThreadProc(ASubscription: TSubscription;
 begin
   Result := procedure
     begin
-      ASubscription.SubscriberMethod.Method.Invoke(ASubscription.Subscriber,
-        [AEvent]);
+      if ASubscription.Active then
+      begin
+        ASubscription.SubscriberMethod.Method.Invoke(ASubscription.Subscriber,
+          [AEvent]);
+      end;
     end;
 end;
 
@@ -140,8 +143,11 @@ function TEventBus.GenerateTProc(ASubscription: TSubscription;
 begin
   Result := procedure
     begin
-      ASubscription.SubscriberMethod.Method.Invoke(ASubscription.Subscriber,
-        [AEvent]);
+      if ASubscription.Active then
+      begin
+        ASubscription.SubscriberMethod.Method.Invoke(ASubscription.Subscriber,
+          [AEvent]);
+      end;
     end;
 end;
 


### PR DESCRIPTION
This is relevant when a procedure has been queued on background thread, or queued to main thread, and is called after shutdown has commenced