### PR TITLE
The testing class TBaseSubscriber needs to make LastEvent, LastEventThreadId thread safe. Otherwise, in Async/Background testing cases (particularly, the 10 parallel tasks spawned by TestBackgroundsPost may try to write simultaneously). Also be careful...

### DIFF
--- a/source/EventBus.Core.pas
+++ b/source/EventBus.Core.pas
@@ -130,7 +130,7 @@ function TEventBus.GenerateTProc(ASubscription: TSubscription; AEvent: IInterfac
 begin
   Result := procedure
     begin
-        InvokeSubscriber(ASubscription, AEvent);
+      InvokeSubscriber(ASubscription, AEvent);
     end;
 end;
 
@@ -234,9 +234,9 @@ begin
 
   try
     LIsMainThread := MainThreadID = TThread.CurrentThread.ThreadID;
-    LType:= TInterfaceHelper.GetQualifiedName( AEvent);
+    LType:= TInterfaceHelper.GetQualifiedName(AEvent);
 
-    FSubscriptionsOfGivenEventType.TryGetValue( LType, LSubscriptions);
+    FSubscriptionsOfGivenEventType.TryGetValue(LType, LSubscriptions);
 
     if (not Assigned(LSubscriptions)) then
       Exit;

--- a/tests/DEBDUnitXTests.dpr
+++ b/tests/DEBDUnitXTests.dpr
@@ -28,10 +28,7 @@ TestInsight.DUnitX.RunRegisteredTests;
 Exit;
 {$ENDIF}
 
-
-
 {$IFDEF CONSOLE_TESTRUNNER}
-
 procedure MainConsole();
 var
   runner: ITestRunner;

--- a/tests/EventBusTestU.pas
+++ b/tests/EventBusTestU.pas
@@ -284,20 +284,20 @@ var
 begin
   GlobalEventBus.RegisterSubscriberForEvents(Subscriber);
 
-  for I := 0 to 10 do
+  for I := 1 to 100 do // Use 100, instead of 10 to TEST
   begin
     LEvent := TBackgroundEvent.Create;
     LMsg := 'TestBackgroundPost';
     LEvent.Data := LMsg;
-    LEvent.Count := I;
+    LEvent.SequenceID := I;
     GlobalEventBus.Post(LEvent);
   end;
   // attend for max 0.500 seconds
 
-  for I := 0 to 50 do
+  for I := 0 to 500 do
     TThread.Sleep(10);
 
-  Assert.AreEqual(10, IBackgroundEvent(Subscriber.LastEvent).Count);
+  Assert.AreEqual(100, Subscriber.Count);
 end;
 
 procedure TEventBusTest.TestBackgroundsPostChannel;


### PR DESCRIPTION
The testing class TBaseSubscriber needs to make LastEvent, LastEventThreadId thread safe. Otherwise, in Async/Background testing cases (particularly, the 10 parallel tasks spawned by TestBackgroundsPost may try to write simultaneously to these properties). Also be careful TestBackgroundsPost may NOT always succeed, because there is no guarantee the 10 parallel tasks finish in a FIFO fashion, which will make the Assert fails (the last event may have a count 9).