### PR TITLE
- Add new generic class function TSubscriberFinder.FindSubscriberMethods<T: TEventBusSubscriberMethodAttribute>, so the redundant code with FindChannelSubscriberMethods and FindEventSubscriberMethod is minimized.

### DIFF
--- a/source/EventBus.Helpers.pas
+++ b/source/EventBus.Helpers.pas
@@ -12,8 +12,8 @@ type
   TRttiUtils = class sealed
   public
     class var Ctx: TRttiContext;
-    class function HasAttribute<T: class>(ARttiMember: TRttiMember; out AAttribute: T): Boolean; overload;
-    class function HasAttribute<T: class>(ARttiMember: TRttiType; out AAttribute: T): Boolean; overload;
+    class function HasAttribute<T: TCustomAttribute>(ARttiMember: TRttiMember; out AAttribute: T): Boolean; overload;
+    class function HasAttribute<T: TCustomAttribute>(ARttiMember: TRttiType; out AAttribute: T): Boolean; overload;
   end;
 
   /// <summary>

--- a/source/EventBus.pas
+++ b/source/EventBus.pas
@@ -280,6 +280,10 @@ type
     ///   Thread mode of the subscriber method
     /// </param>
     constructor Create(const AChannel: string; AThreadMode: TThreadMode = TThreadMode.Posting);
+
+    /// <summary>
+    ///   Name of the channel.
+    /// </summary>
     property Channel: string read Get_Channel;
   end;
 

--- a/source/EventBus.pas
+++ b/source/EventBus.pas
@@ -95,11 +95,12 @@ type
     ///   Channel attribute.
     /// </param>
     /// <exception cref="EInvalidSubscriberMethod">
-    ///   When any subscriber method of the subscriber object has invalid number of arguments or invalid
-    ///   argument type.
+    ///   Throws whenever a subscriber method of the subscriber object has
+    ///   invalid number of arguments or invalid argument type.
     /// </exception>
     /// <exception cref="EObjectHasNoSubscriberMethods">
-    ///   When the subscriber object contains no subscriber methods.
+    ///   Throws when the subscriber object does not have any methods with
+    ///   Channel attribute defined.
     /// </exception>
     procedure RegisterSubscriberForChannels(ASubscriber: TObject);
 
@@ -115,15 +116,16 @@ type
     ///   Registers a subscriber for interface-typed events.
     /// </summary>
     /// <param name="ASubscriber">
-    ///   The subscriber object to register, which should have methods with Subscribe attributes.
-    ///   attribute.
+    ///   The subscriber object to register, which should have methods with
+    ///   Subscribe attributes. attribute.
     /// </param>
     /// <exception cref="EInvalidSubscriberMethod">
-    ///   When any subscriber method of the subscriber object has invalid number of arguments or invalid
-    ///   argument type.
+    ///   Throws whenever a subscriber method of the subscriber object has
+    ///   invalid number of arguments or invalid argument type.
     /// </exception>
     /// <exception cref="EObjectHasNoSubscriberMethods">
-    ///   When the subscriber object contains no subscriber methods.
+    ///   Throws when the subscriber object does not have any methods with
+    ///   Subscribe attribute defined.
     /// </exception>
     procedure RegisterSubscriberForEvents(ASubscriber: TObject);
 
@@ -218,15 +220,13 @@ type
   );
 
 type
-  /// <summary>
-  ///   Subscriber attribute must be specified to subscriber methods in
-  ///   order to receive interface-typed events.
-  /// </summary>
-  SubscribeAttribute = class(TCustomAttribute)
-  private
+  TEventBusSubscriberMethodAttribute = class abstract (TCustomAttribute)
+  strict private
     FContext: string;
     FThreadMode: TThreadMode;
-  public
+  strict protected
+    function Get_ArgTypeKind: TTypeKind; virtual; abstract;
+
     /// <param name="AThreadMode">
     ///   Thread mode of the subscriber method.
     /// </param>
@@ -234,8 +234,8 @@ type
     ///   Context of event.
     /// </param>
     /// <seealso cref="TEventBusThreadMode" />
-    constructor Create(AThreadMode: TThreadMode = TThreadMode.Posting; const AContext: string = '');
-
+    constructor Create(AThreadMode: TThreadMode; const AContext: string);
+  public
     /// <summary>
     ///   Thread mode of the subscriber method.
     /// </summary>
@@ -245,16 +245,33 @@ type
     ///   Context of the subscriber method.
     /// </summary>
     property Context: string read FContext;
+
+    /// <summary>
+    ///   Required argment type of the subscriber method.
+    /// </summary>
+    property ArgTypeKind: TTypeKind read Get_ArgTypeKind;
+  end;
+
+  /// <summary>
+  ///   Subscriber attribute must be specified to subscriber methods in
+  ///   order to receive interface-typed events.
+  /// </summary>
+  SubscribeAttribute = class(TEventBusSubscriberMethodAttribute)
+  strict protected
+    function Get_ArgTypeKind: TTypeKind; override;
+  public
+    constructor Create(AThreadMode: TThreadMode = TThreadMode.Posting; const AContext: string = '');
   end;
 
   /// <summary>
   ///   Channel attribute must be specified to subscriber methods in order
   ///   to receive named-channel messages.
   /// </summary>
-  ChannelAttribute = class(TCustomAttribute)
-  private
-    FChannel: string;
-    FThreadMode: TThreadMode;
+  ChannelAttribute = class(TEventBusSubscriberMethodAttribute)
+  strict private
+    function Get_Channel: string;
+  strict protected
+    function Get_ArgTypeKind: TTypeKind; override;
   public
     /// <param name="AChannel">
     ///   Name of the channel
@@ -263,22 +280,21 @@ type
     ///   Thread mode of the subscriber method
     /// </param>
     constructor Create(const AChannel: string; AThreadMode: TThreadMode = TThreadMode.Posting);
-
-    /// <summary>
-    ///   Thread mode of the subscriber method
-    /// </summary>
-    property ThreadMode: TThreadMode read FThreadMode;
-
-    /// <summary>
-    ///   Associated channel of the subscriber method.
-    /// </summary>
-    property Channel: string read FChannel;
+    property Channel: string read Get_Channel;
   end;
 
+  /// <summary>
+  ///   Throws whenever a subscriber method has invalid number of arguments or
+  ///   invalid argument type.
+  /// </summary>
   EInvalidSubscriberMethod = class(Exception)
 
   end;
 
+  /// <summary>
+  ///   Throws when a subscriber object does not have any methods with Channel
+  ///   or Subscribe attribute defined.
+  /// </summary>
   EObjectHasNoSubscriberMethods = class(Exception)
 
   end;
@@ -341,15 +357,35 @@ end;
 
 constructor SubscribeAttribute.Create(AThreadMode: TThreadMode = TThreadMode.Posting; const AContext: string = '');
 begin
+  inherited Create(AThreadMode, AContext);
+end;
+
+function SubscribeAttribute.Get_ArgTypeKind: TTypeKind;
+begin
+  Result := TTypeKind.tkInterface;
+end;
+
+constructor ChannelAttribute.Create(const AChannel: string; AThreadMode: TThreadMode = TThreadMode.Posting);
+begin
+  inherited Create(AThreadMode, AChannel);
+end;
+
+function ChannelAttribute.Get_ArgTypeKind: TTypeKind;
+begin
+  Result := TTypeKind.tkUString;
+end;
+
+function ChannelAttribute.Get_Channel: string;
+begin
+  Result := Context;
+end;
+
+constructor TEventBusSubscriberMethodAttribute.Create(AThreadMode: TThreadMode; const AContext: string);
+begin
   inherited Create;
   FContext := AContext;
   FThreadMode := AThreadMode;
 end;
 
-constructor ChannelAttribute.Create(const AChannel: string; AThreadMode: TThreadMode = TThreadMode.Posting);
-begin
-  FThreadMode := AThreadMode;
-  FChannel := AChannel;
-end;
-
 end.
+


### PR DESCRIPTION
- Enhance the code to address Issue #38, https://github.com/spinettaro/delphi-event-bus/issues/38