### PR TITLE
Dkounal instancecontext

### DIFF
--- a/source/EventBus.Subscribers.pas
+++ b/source/EventBus.Subscribers.pas
@@ -58,6 +58,11 @@ type
       const AContext: string = ''; APriority: Integer = 1);
 
     /// <summary>
+    ///   Changes the Context
+    /// </summary>
+    procedure setcontext(const newcontext:string);
+
+    /// <summary>
     ///   Encodes Context string and EventType string to a Category string,
     ///   representing the category a subscriber method belongs to.
     /// </summary>
@@ -217,6 +222,11 @@ end;
 function TSubscriberMethod.Get_Category: string;
 begin
   Result := EncodeCategory(Context, EventType);
+end;
+
+procedure TSubscriberMethod.setcontext(const newcontext: string);
+begin
+  FContext:=newcontext;
 end;
 
 class function TSubscribersFinder.FindSubscriberMethods<T>(ASubscriberClass: TClass;

--- a/source/EventBus.pas
+++ b/source/EventBus.pas
@@ -153,6 +153,23 @@ type
     ///   The subscriber object to register, which should have methods with
     ///   Subscribe attributes.
     /// </param>
+    /// <param name="newcontext">
+    ///   The Instance based Context that will the context if the attribute 
+    ///   based context is defined as InstanceBased.
+    /// </param>
+    /// <exception cref="EObjectHasNoSubscriberMethods">
+    ///   Throws when the subscriber object does not have any methods with
+    ///   Subscribe attribute defined.
+    /// </exception>
+    procedure RegisterCustomContextSubscriberForEvents(ASubscriber: TObject; newcontext:string);
+
+/// <summary>
+    ///   Registers a subscriber for interface-typed events.
+    /// </summary>
+    /// <param name="ASubscriber">
+    ///   The subscriber object to register, which should have methods with
+    ///   Subscribe attributes.
+    /// </param>
     /// <exception cref="EInvalidSubscriberMethod">
     ///   Throws whenever a subscriber method of the subscriber object has
     ///   invalid number of arguments or invalid argument type.


### PR DESCRIPTION
Add the possibility to define instance based Context:
If a property with Context named "InstanceBased" exists, then with the RegisterCustomContextSubscriberForEvents you can change the context per Object instance that uses this type of Interface-message.