### PR TITLE
Further enhanced the code for allowing dynamic context.  Sticking to the principle "better be explicit than implicit".  Created an enum TContextOption = (UseInstanceContext, UseAttributeContext). Added a new overloaded constructor for TSubscriberAttrib...

### DIFF
--- a/source/EventBus.Core.pas
+++ b/source/EventBus.Core.pas
@@ -66,7 +66,7 @@ type
 
     procedure InvokeSubscriber(ASubscription: TSubscription; const Args: array of TValue);
     function IsRegistered<T: TSubscriberMethodAttribute>(ASubscriber: TObject): Boolean;
-    procedure RegisterSubscriber<T: TSubscriberMethodAttribute>(ASubscriber: TObject; ARaiseExcIfEmpty: Boolean);
+    procedure RegisterSubscriber<T: TSubscriberMethodAttribute>(ASubscriber: TObject; ARaiseExcIfEmpty: Boolean; const AInstanceContext: string);
     procedure Subscribe<T: TSubscriberMethodAttribute>(ASubscriber: TObject; ASubscriberMethod: TSubscriberMethod);
     procedure UnregisterSubscriber<T: TSubscriberMethodAttribute>(ASubscriber: TObject);
     procedure Unsubscribe<T: TSubscriberMethodAttribute>(ASubscriber: TObject; const AMethodCategory: TMethodCategory);
@@ -84,8 +84,8 @@ type
     procedure Post(const AEvent: IInterface; const AContext: string = ''); overload;
     procedure RegisterSubscriberForChannels(ASubscriber: TObject);
     procedure SilentRegisterSubscriberForChannels(ASubscriber: TObject);
-    procedure RegisterSubscriberForEvents(ASubscriber: TObject);
-    procedure SilentRegisterSubscriberForEvents(ASubscriber: TObject);
+    procedure RegisterSubscriberForEvents(ASubscriber: TObject; const AInstanceContext: string = '');
+    procedure SilentRegisterSubscriberForEvents(ASubscriber: TObject; const AInstanceContext: string = '');
     procedure UnregisterForChannels(ASubscriber: TObject);
     procedure UnregisterForEvents(ASubscriber: TObject);
     {$ENDREGION}
@@ -294,7 +294,7 @@ begin
   end;
 end;
 
-procedure TEventBus.RegisterSubscriber<T>(ASubscriber: TObject; ARaiseExcIfEmpty: Boolean);
+procedure TEventBus.RegisterSubscriber<T>(ASubscriber: TObject; ARaiseExcIfEmpty: Boolean; const AInstanceContext: string);
 var
   LSubscriberClass: TClass;
   LSubscriberMethods: TArray<TSubscriberMethod>;
@@ -305,7 +305,13 @@ begin
   try
     LSubscriberClass := ASubscriber.ClassType;
     LSubscriberMethods := TSubscribersFinder.FindSubscriberMethods<T>(LSubscriberClass, ARaiseExcIfEmpty);
-    for LSubscriberMethod in LSubscriberMethods do Subscribe<T>(ASubscriber, LSubscriberMethod);
+
+    for LSubscriberMethod in LSubscriberMethods do begin
+      // If the method do not have its Context specified, we assign the instance-specific context to it.
+      // Note - the instance-specific context itself may be empty.
+      if LSubscriberMethod.Context = '' then LSubscriberMethod.SetNewContext(AInstanceContext);
+      Subscribe<T>(ASubscriber, LSubscriberMethod);
+    end;
   finally
     FMultiReadExclWriteSync.EndWrite;
   end;
@@ -313,22 +319,22 @@ end;
 
 procedure TEventBus.RegisterSubscriberForChannels(ASubscriber: TObject);
 begin
-  RegisterSubscriber<ChannelAttribute>(ASubscriber, True);
+  RegisterSubscriber<ChannelAttribute>(ASubscriber, True, '');
 end;
 
-procedure TEventBus.RegisterSubscriberForEvents(ASubscriber: TObject);
+procedure TEventBus.RegisterSubscriberForEvents(ASubscriber: TObject; const AInstanceContext: string = '');
 begin
-  RegisterSubscriber<SubscribeAttribute>(ASubscriber, True);
+  RegisterSubscriber<SubscribeAttribute>(ASubscriber, True, AInstanceContext);
 end;
 
 procedure TEventBus.SilentRegisterSubscriberForChannels(ASubscriber: TObject);
 begin
-  RegisterSubscriber<ChannelAttribute>(ASubscriber, False);
+  RegisterSubscriber<ChannelAttribute>(ASubscriber, False, '');
 end;
 
-procedure TEventBus.SilentRegisterSubscriberForEvents(ASubscriber: TObject);
+procedure TEventBus.SilentRegisterSubscriberForEvents(ASubscriber: TObject; const AInstanceContext: string = '');
 begin
-  RegisterSubscriber<SubscribeAttribute>(ASubscriber, False);
+  RegisterSubscriber<SubscribeAttribute>(ASubscriber, False, AInstanceContext);
 end;
 
 procedure TEventBus.Subscribe<T>(ASubscriber: TObject; ASubscriberMethod: TSubscriberMethod);

--- a/source/EventBus.Subscribers.pas
+++ b/source/EventBus.Subscribers.pas
@@ -33,6 +33,7 @@ type
   TSubscriberMethod = class sealed(TObject)
   strict private
     FContext: string;
+    FContextOption: TContextOption;
     FEventType: string;
     FMethod: TRttiMethod;
     FPriority: Integer;
@@ -49,13 +50,12 @@ type
     ///   Designated thread mode.
     /// </param>
     /// <param name="AContext">
-    ///   Context of the method, as obtained from the SubscriberAttribute.
+    ///   Context of the method.
     /// </param>
     /// <param name="APriority">
     ///   Dispatching priority of the method.
     /// </param>
-    constructor Create(ARttiMethod: TRttiMethod; const AEventType: string; AThreadMode: TThreadMode;
-      const AContext: string = ''; APriority: Integer = 1);
+    constructor Create(ARttiMethod: TRttiMethod; const AEventType: string; AThreadMode: TThreadMode; AContextOption: TContextOption; const AContext: string = ''; APriority: Integer = 1);
 
     /// <summary>
     ///   Encodes Context string and EventType string to a Category string,
@@ -93,6 +93,9 @@ type
     ///   Context of the subscriber method.
     /// </summary>
     property Context: string read FContext;
+
+    property ContextOption: TContextOption read FContextOption;
+
     /// <summary>
     ///   Event type of the subscriber method. It is actually the fully
     ///   qualified name of the event type.
@@ -193,13 +196,13 @@ implementation
 uses
   System.SysUtils, System.TypInfo, EventBus.Helpers;
 
-constructor TSubscriberMethod.Create(ARttiMethod: TRttiMethod; const AEventType: string; AThreadMode: TThreadMode;
-  const AContext: string = ''; APriority: Integer = 1);
+constructor TSubscriberMethod.Create(ARttiMethod: TRttiMethod; const AEventType: string; AThreadMode: TThreadMode; AContextOption: TContextOption; const AContext: string = ''; APriority: Integer = 1);
 begin
   FMethod := ARttiMethod;
   FEventType := AEventType;
   FThreadMode := AThreadMode;
   FContext := AContext;
+  FContextOption := AContextOption;
   FPriority := APriority;
 end;
 
@@ -271,7 +274,7 @@ begin
       end;
 
       LEventType := LMethod.GetParameters[0].ParamType.QualifiedName;
-      LSubMethod := TSubscriberMethod.Create(LMethod, LEventType, LAttribute.ThreadMode, LAttribute.Context);
+      LSubMethod := TSubscriberMethod.Create(LMethod, LEventType, LAttribute.ThreadMode, LAttribute.ContextOption, LAttribute.Context);
 
       {$IF CompilerVersion >= 28.0}
       Result := Result + [LSubMethod];

--- a/source/EventBus.Subscribers.pas
+++ b/source/EventBus.Subscribers.pas
@@ -49,7 +49,7 @@ type
     ///   Designated thread mode.
     /// </param>
     /// <param name="AContext">
-    ///   Context of the method.
+    ///   Context of the method, as obtained from the SubscriberAttribute.
     /// </param>
     /// <param name="APriority">
     ///   Dispatching priority of the method.
@@ -75,6 +75,14 @@ type
     ///   The object to compare
     /// </param>
     function Equals(AObject: TObject): Boolean; override;
+
+    /// <summary>
+    ///   Set a new context to the method, overriding the existing one.
+    /// </summary>
+    /// <param name="ANewContext">
+    ///   The new context string to set.
+    /// </param>
+    procedure SetNewContext(const ANewContext: string);
 
     /// <summary>
     ///   Category of the subscriber method. Internally it takes value of "Context:EventType".
@@ -217,6 +225,11 @@ end;
 function TSubscriberMethod.Get_Category: string;
 begin
   Result := EncodeCategory(Context, EventType);
+end;
+
+procedure TSubscriberMethod.SetNewContext(const ANewContext: string);
+begin
+  FContext := ANewContext;
 end;
 
 class function TSubscribersFinder.FindSubscriberMethods<T>(ASubscriberClass: TClass;

--- a/source/EventBus.pas
+++ b/source/EventBus.pas
@@ -134,12 +134,12 @@ type
     /// </summary>
     /// <param name="ASubscriber">
     ///   The subscriber object to register, which should have methods with
-    ///   Subscribe attributes.
+    ///   Subscribe attribute specified.
     /// </param>
     /// <param name="AInstanceContext">
-    ///   An instance-specific context specified during runtime. If a
-    ///   subscriber method has its SubscriberAttribute.Context unspecified,
-    ///   then the instance context specified here will apply to that method.
+    ///   An instance-specific context. If a subscriber method has its
+    ///   SubscriberAttribute.ContextOption set to UseInstanceContext, then the
+    ///   instance context specified here will be applied to that method.
     /// </param>
     /// <exception cref="EInvalidSubscriberMethod">
     ///   Throws whenever a subscriber method of the subscriber object has
@@ -152,6 +152,11 @@ type
     /// <exception cref="ESubscriberMethodAlreadyRegistered">
     ///   Throws when the subscriber object has already been registered.
     /// </exception>
+    /// <exception cref="EUnspecifiedInstanceContext">
+    ///   Throws when the subscriber object has methods with UseInstanceContext
+    ///   enabled, but AInstanceContext is empty.
+    /// </exception>
+    /// <seealso cref="TContextOption" />
     procedure RegisterSubscriberForEvents(ASubscriber: TObject; const AInstanceContext: string = '');
 
     /// <summary>
@@ -159,25 +164,30 @@ type
     /// </summary>
     /// <param name="ASubscriber">
     ///   The subscriber object to register, which should have methods with
-    ///   Subscribe attributes.
+    ///   Subscribe attribute specified.
     /// </param>
     /// <param name="AInstanceContext">
-    ///   An instance-specific context specified during runtime. If a
-    ///   subscriber method has its SubscriberAttribute.Context value
-    ///   unspecified then the instance context specified here will apply to
-    ///   that method.
+    ///   An instance-specific context. If a subscriber method has its
+    ///   SubscriberAttribute.ContextOption set to UseInstanceContext, then the
+    ///   instance context specified here will be applied to that method.
     /// </param>
     /// <exception cref="EInvalidSubscriberMethod">
-    ///   Throws whenever a subscriber method of the subscriber object has
-    ///   invalid number of arguments or invalid argument type.
+    ///   Throws when a subscriber method of the subscriber object has invalid
+    ///   number of arguments or invalid argument type.
     /// </exception>
     /// <exception cref="ESubscriberMethodAlreadyRegistered">
     ///   Throws when the subscriber object has already been registered.
     /// </exception>
+    /// <exception cref="EUnspecifiedInstanceContext">
+    ///   Throws when the subscriber object has methods with UseInstanceContext
+    ///   enabled, but AInstanceContext is empty.
+    /// </exception>
     /// <remarks>
-    ///   There won't be any exception thrown if the subscriber object has no
-    ///   subscriber methods defined.
+    ///   EObjectHasNoSubscriberMethods will not be thrown when the subscriber
+    ///   object has no subscriber methods defined. To have the exception
+    ///   enabled, use <br />RegisterSubscriberForEvents method instead. <br />
     /// </remarks>
+    /// <seealso cref="TContextOption" />
     procedure SilentRegisterSubscriberForEvents(ASubscriber: TObject; const AInstanceContext: string = '');
 
     /// <summary>
@@ -270,22 +280,31 @@ type
     Background
   );
 
+  /// <summary>
+  ///   Defines context option for the subscriber method.
+  /// </summary>
+  TContextOption = (
+    /// <summary>
+    ///   The subscriber method will use the instance context, which will be
+    ///   specified when registering the subscriber object at run-time. <br />
+    /// </summary>
+    UseInstanceContext,
+    /// <summary>
+    ///   The subscriber method will use the context as specified with the
+    ///   subscriber method in-place as part of its compile-time attribute.
+    /// </summary>
+    UseAttributeContext
+  );
+
 type
   TSubscriberMethodAttribute = class abstract (TCustomAttribute)
   strict private
     FContext: string;
+    FContextOption: TContextOption;
     FThreadMode: TThreadMode;
   strict protected
     function Get_ArgTypeKind: TTypeKind; virtual; abstract;
-
-    /// <param name="AThreadMode">
-    ///   Thread mode of the subscriber method.
-    /// </param>
-    /// <param name="AContext">
-    ///   Context of event. If set to an empty string, then instance context will be used.
-    /// </param>
-    /// <seealso cref="TEventBusThreadMode" />
-    constructor Create(AThreadMode: TThreadMode; const AContext: string);
+    constructor Create(AThreadMode: TThreadMode; AContextOption: TContextOption; const AContext: string);
   public
     /// <summary>
     ///   Required argment type of the subscriber method.
@@ -293,15 +312,19 @@ type
     property ArgTypeKind: TTypeKind read Get_ArgTypeKind;
 
     /// <summary>
-    ///   Thread mode of the subscriber method.
-    /// </summary>
-    property ThreadMode: TThreadMode read FThreadMode;
-
-    /// <summary>
     ///   Context of the subscriber method.
     /// </summary>
     property Context: string read FContext;
 
+    /// <summary>
+    ///   Context option of the subscriber method.
+    /// </summary>
+    property ContextOption: TContextOption read FContextOption;
+
+    /// <summary>
+    ///   Thread mode of the subscriber method.
+    /// </summary>
+    property ThreadMode: TThreadMode read FThreadMode;
   end;
 
   /// <summary>
@@ -312,7 +335,8 @@ type
   strict protected
     function Get_ArgTypeKind: TTypeKind; override;
   public
-    constructor Create(AThreadMode: TThreadMode = TThreadMode.Posting; const AContext: string = '');
+    constructor Create(AThreadMode: TThreadMode = TThreadMode.Posting; const AContext: string = ''); overload;
+    constructor Create(AContextOption: TContextOption; AThreadMode: TThreadMode = TThreadMode.Posting; const AContext: string = ''); overload;
   end;
 
   /// <summary>
@@ -337,6 +361,13 @@ type
     ///   Name of the channel.
     /// </summary>
     property Channel: string read Get_Channel;
+  end;
+
+  /// <summary>
+  ///   Throws whenever a subscriber method has UseInstanceContext enabled but
+  ///   the supplied instance context is an empty string.
+  /// </summary>
+  EUnspecifiedInstanceContext = class(Exception)
   end;
 
   /// <summary>
@@ -430,7 +461,12 @@ end;
 
 constructor SubscribeAttribute.Create(AThreadMode: TThreadMode = TThreadMode.Posting; const AContext: string = '');
 begin
-  inherited Create(AThreadMode, AContext);
+  inherited Create(AThreadMode, TContextOption.UseAttributeContext, AContext);
+end;
+
+constructor SubscribeAttribute.Create(AContextOption: TContextOption; AThreadMode: TThreadMode = TThreadMode.Posting; const AContext: string = '');
+begin
+  inherited Create(AThreadMode, AContextOption, AContext);
 end;
 
 function SubscribeAttribute.Get_ArgTypeKind: TTypeKind;
@@ -440,7 +476,7 @@ end;
 
 constructor ChannelAttribute.Create(const AChannel: string; AThreadMode: TThreadMode = TThreadMode.Posting);
 begin
-  inherited Create(AThreadMode, AChannel);
+  inherited Create(AThreadMode, TContextOption.UseAttributeContext, AChannel);
 end;
 
 function ChannelAttribute.Get_ArgTypeKind: TTypeKind;
@@ -453,10 +489,11 @@ begin
   Result := Context;
 end;
 
-constructor TSubscriberMethodAttribute.Create(AThreadMode: TThreadMode; const AContext: string);
+constructor TSubscriberMethodAttribute.Create(AThreadMode: TThreadMode; AContextOption: TContextOption; const AContext: string);
 begin
   inherited Create;
   FContext := AContext;
+  FContextOption := AContextOption;
   FThreadMode := AThreadMode;
 end;
 

--- a/source/EventBus.pas
+++ b/source/EventBus.pas
@@ -136,6 +136,11 @@ type
     ///   The subscriber object to register, which should have methods with
     ///   Subscribe attributes.
     /// </param>
+    /// <param name="AInstanceContext">
+    ///   An instance-specific context specified during runtime. If a
+    ///   subscriber method has its SubscriberAttribute.Context unspecified,
+    ///   then the instance context specified here will apply to that method.
+    /// </param>
     /// <exception cref="EInvalidSubscriberMethod">
     ///   Throws whenever a subscriber method of the subscriber object has
     ///   invalid number of arguments or invalid argument type.
@@ -144,7 +149,10 @@ type
     ///   Throws when the subscriber object does not have any methods with
     ///   Subscribe attribute defined.
     /// </exception>
-    procedure RegisterSubscriberForEvents(ASubscriber: TObject);
+    /// <exception cref="ESubscriberMethodAlreadyRegistered">
+    ///   Throws when the subscriber object has already been registered.
+    /// </exception>
+    procedure RegisterSubscriberForEvents(ASubscriber: TObject; const AInstanceContext: string = '');
 
     /// <summary>
     ///   Registers a subscriber for interface-typed events.
@@ -153,15 +161,24 @@ type
     ///   The subscriber object to register, which should have methods with
     ///   Subscribe attributes.
     /// </param>
+    /// <param name="AInstanceContext">
+    ///   An instance-specific context specified during runtime. If a
+    ///   subscriber method has its SubscriberAttribute.Context value
+    ///   unspecified then the instance context specified here will apply to
+    ///   that method.
+    /// </param>
     /// <exception cref="EInvalidSubscriberMethod">
     ///   Throws whenever a subscriber method of the subscriber object has
     ///   invalid number of arguments or invalid argument type.
+    /// </exception>
+    /// <exception cref="ESubscriberMethodAlreadyRegistered">
+    ///   Throws when the subscriber object has already been registered.
     /// </exception>
     /// <remarks>
     ///   There won't be any exception thrown if the subscriber object has no
     ///   subscriber methods defined.
     /// </remarks>
-    procedure SilentRegisterSubscriberForEvents(ASubscriber: TObject);
+    procedure SilentRegisterSubscriberForEvents(ASubscriber: TObject; const AInstanceContext: string = '');
 
     /// <summary>
     ///   Unregisters a subscriber from receiving interface-typed events.
@@ -265,11 +282,16 @@ type
     ///   Thread mode of the subscriber method.
     /// </param>
     /// <param name="AContext">
-    ///   Context of event.
+    ///   Context of event. If set to an empty string, then instance context will be used.
     /// </param>
     /// <seealso cref="TEventBusThreadMode" />
     constructor Create(AThreadMode: TThreadMode; const AContext: string);
   public
+    /// <summary>
+    ///   Required argment type of the subscriber method.
+    /// </summary>
+    property ArgTypeKind: TTypeKind read Get_ArgTypeKind;
+
     /// <summary>
     ///   Thread mode of the subscriber method.
     /// </summary>
@@ -280,10 +302,6 @@ type
     /// </summary>
     property Context: string read FContext;
 
-    /// <summary>
-    ///   Required argment type of the subscriber method.
-    /// </summary>
-    property ArgTypeKind: TTypeKind read Get_ArgTypeKind;
   end;
 
   /// <summary>

--- a/tests/BOs.pas
+++ b/tests/BOs.pas
@@ -111,7 +111,12 @@ type
     procedure OnSimpleBackgroundChannel(AMsg: string);
   end;
 
-  TSubscriberCopy = class(TBaseSubscriber)
+  TSubscriberWithInstanceContext = class(TBaseSubscriber)
+    [Subscribe(UseInstanceContext)]
+    procedure OnSimpleEventWithInstanceContext(AEvent: IEventBusEvent);
+  end;
+
+   TSubscriberCopy = class(TBaseSubscriber)
     [Subscribe]
     procedure OnSimpleEvent(AEvent: IEventBusEvent);
   end;
@@ -389,6 +394,14 @@ procedure TInvalidArgTypeSubscriber.OnEvent(AEvent: Integer);
 begin
   // No-Op
 end;
+
+procedure TSubscriberWithInstanceContext.OnSimpleEventWithInstanceContext(AEvent: IEventBusEvent);
+begin
+  LastEvent := AEvent;
+  LastEventThreadID := TThread.CurrentThread.ThreadID;
+  Event.SetEvent;
+end;
+
 
 end.
 

--- a/tests/EventBusTestU.pas
+++ b/tests/EventBusTestU.pas
@@ -20,6 +20,8 @@ type
     procedure TestRegisterUnregisterMultipleSubscriberEvents;
     [Test]
     procedure TestDuplicateRegister;
+    [Test]
+    procedure TestRegisterSubscriberObjectWithInstanceContext;
 
     [Test]
     procedure TestRegisterUnregisterChannels;
@@ -589,6 +591,42 @@ begin
 
   LSubscriber.Free;
 end;
+
+
+procedure TEventBusTest.TestRegisterSubscriberObjectWithInstanceContext;
+var
+  LSubscriber: TSubscriberCopy;
+  LEvent: IEventBusEvent;
+  LMsg, LInstanceContext: string;
+begin
+  LSubscriber := TSubscriberCopy.Create;
+
+  try
+    // Test for an explicit instance context
+    LInstanceContext := 'INSTANCE_CTX';
+    GlobalEventBus.RegisterSubscriberForEvents(LSubscriber, LInstanceContext);
+    LEvent := TEventBusEvent.Create;
+    LMsg := 'TestSimplePost with instance context';
+    LEvent.Data := LMsg;
+    GlobalEventBus.Post(LEvent, LInstanceContext);
+    Assert.IsTrue(GlobalEventBus.IsRegisteredForEvents(LSubscriber));
+    Assert.AreEqual(LMsg, LSubscriber.LastEvent.Data);
+    GlobalEventBus.UnRegisterForEvents(LSubscriber);
+
+    // Test without an explict instance context
+    GlobalEventBus.RegisterSubscriberForEvents(LSubscriber);
+    LMsg := 'TestSimplePost without instance context';
+    LEvent.Data := LMsg;
+    GlobalEventBus.Post(LEvent);
+    Assert.IsTrue(GlobalEventBus.IsRegisteredForEvents(LSubscriber));
+    Assert.AreEqual(LMsg, LSubscriber.LastEvent.Data);
+    GlobalEventBus.UnRegisterForEvents(LSubscriber);
+
+  finally
+    LSubscriber.Free;
+  end;
+end;
+
 
 initialization
   TDUnitX.RegisterTestFixture(TEventBusTest);

--- a/tests/EventBusTestU.pas
+++ b/tests/EventBusTestU.pas
@@ -18,6 +18,8 @@ type
     procedure TestIsRegisteredFalseAfterUnregisterEvents;
     [Test]
     procedure TestRegisterUnregisterMultipleSubscriberEvents;
+    [Test]
+    procedure TestDuplicateRegister;
 
     [Test]
     procedure TestRegisterUnregisterChannels;
@@ -485,6 +487,27 @@ begin
   Assert.AreNotEqual(MainThreadID, Subscriber.LastEventThreadID);
 end;
 
+procedure TEventBusTest.TestDuplicateRegister;
+var
+  LSubscriber: TSubscriberCopy;
+begin
+  LSubscriber := TSubscriberCopy.Create;
+
+  try
+    GlobalEventBus.RegisterSubscriberForEvents(LSubscriber);
+
+    Assert.WillRaise(
+      procedure begin
+        GlobalEventBus.RegisterSubscriberForEvents(LSubscriber);
+      end
+      ,
+      ESubscriberMethodAlreadyRegistered
+      ,
+      'Duplicate registering subscriber for events.');
+  finally
+    LSubscriber.Free;
+  end;
+end;
 
 procedure TEventBusTest.TestEmptySubscriber;
 var

--- a/tests/EventBusTestU.pas
+++ b/tests/EventBusTestU.pas
@@ -595,12 +595,12 @@ end;
 
 procedure TEventBusTest.TestRegisterSubscriberObjectWithInstanceContext;
 var
-  LSubscriber: TSubscriberCopy;
+  LSubscriber: TSubscriberWithInstanceContext;
   LEvent: IEventBusEvent;
   LMsg, LInstanceContext: string;
 begin
-  LSubscriber := TSubscriberCopy.Create;
-
+  LSubscriber := TSubscriberWithInstanceContext.Create;
+  Assert.IsTrue(True);
   try
     // Test for an explicit instance context
     LInstanceContext := 'INSTANCE_CTX';
@@ -612,16 +612,6 @@ begin
     Assert.IsTrue(GlobalEventBus.IsRegisteredForEvents(LSubscriber));
     Assert.AreEqual(LMsg, LSubscriber.LastEvent.Data);
     GlobalEventBus.UnRegisterForEvents(LSubscriber);
-
-    // Test without an explict instance context
-    GlobalEventBus.RegisterSubscriberForEvents(LSubscriber);
-    LMsg := 'TestSimplePost without instance context';
-    LEvent.Data := LMsg;
-    GlobalEventBus.Post(LEvent);
-    Assert.IsTrue(GlobalEventBus.IsRegisteredForEvents(LSubscriber));
-    Assert.AreEqual(LMsg, LSubscriber.LastEvent.Data);
-    GlobalEventBus.UnRegisterForEvents(LSubscriber);
-
   finally
     LSubscriber.Free;
   end;


### PR DESCRIPTION
...ute class.  Updated testing case accordingly.