### PR TITLE
Fixes #78 (RAD Studio 12 shows a deprecation warning for DisposeOf)

### DIFF
--- a/source/EventBus.Helpers.pas
+++ b/source/EventBus.Helpers.pas
@@ -212,7 +212,7 @@ end;
 
 class destructor TInterfaceHelper.Destroy;
 begin
-  FInterfaceTypes.DisposeOf;
+  FInterfaceTypes.Free;
 end;
 
 class function TInterfaceHelper.GetQualifiedName(const AIntf: IInterface): string;


### PR DESCRIPTION
This PR just fixes the abovementioned warning.