### PR TITLE
Issue with TInterfaceHelper.RefreshCache durch the programm termination

### DIFF
--- a/source/EventBus.Helpers.pas
+++ b/source/EventBus.Helpers.pas
@@ -212,6 +212,7 @@ end;
 
 class destructor TInterfaceHelper.Destroy;
 begin
+  WaitIfCaching;
   FInterfaceTypes.Free;
 end;
 


### PR DESCRIPTION
During program termination, the anonymous thread within TInterfaceHelper.RefreshCache is not finished, which causes a GPF.
It needs to wait for cache to finish within TInterfaceHelper destructor.